### PR TITLE
Allow for correlation threshold calculation based on Fisher-transformed standard deviation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["hatchling>=1.8.0"]
 [project]
 name = "scCompare"
 description = "Compare 2 single-cell RNAseq datasets"
-version = "0.1.3"
+version = "0.2.0"
 license = { text = "BSD-3" }
 dependencies = [
     "anndata>=0.8",

--- a/scCompare/helpers.py
+++ b/scCompare/helpers.py
@@ -454,10 +454,11 @@ def derive_statistical_group_cutoff(
         n_stdev (optional): Standard deviation cutoff if using fisher transformation.
             Ignored if `use_fisher` = `False`. Default = 2.6.
         n_mad_floor (optional): Automatically calculate MAD, but can't be lower than
-            `n_mad_floor`. If set to `None`, no lower bound. Default = 5.
+            `n_mad_floor`. If set to `None`, no lower bound. Ignored if
+            `use_fisher = True`. Default = 5.
         n_mad (optional): Use exactly this many MADs to calculate statistical cutoffs.
             If `None`, use `n_mad_floor` and automatically calculate MAD instead.
-            Default = `None`.
+            Ignored if `use_fisher = True`. Default = `None`.
 
     Returns:
         A mapping of cluster names to cutoff values (one for each cluster).

--- a/scCompare/helpers.py
+++ b/scCompare/helpers.py
@@ -484,7 +484,9 @@ def _derive_statistical_group_cutoff_fisher(
     for cluster in clusters:
         group = adata_map.obs["asgd_pearson"][adata_map.obs[cluster_key] == cluster]
         transform = np.arctanh(group)
-        stat_group_cutoff[cluster] = transform.mean() - n_stdev * transform.std()
+        stat_group_cutoff[cluster] = np.tanh(
+            transform.mean() - n_stdev * transform.std()
+        )
 
     canon_label_asgd = []
     for i in range(len(adata_map.obs)):

--- a/scCompare/helpers.py
+++ b/scCompare/helpers.py
@@ -439,7 +439,7 @@ def derive_statistical_group_cutoff(
     adata_map: anndata.AnnData,
     cluster_key: str,
     use_fisher: bool = False,
-    n_stdev: float = 3,
+    n_stdev: float = 2.6,
     n_mad_floor: float | None = 5,
     n_mad: float | None = None,
     show_plot: bool = True,
@@ -452,7 +452,7 @@ def derive_statistical_group_cutoff(
         use_fisher (optional): Whether or not to use a fisher-transformed correlation to
             derive a threshold for cutting off correlations. Default = `False`.
         n_stdev (optional): Standard deviation cutoff if using fisher transformation.
-            Ignored if `use_fisher` = `False`. Default = 3.
+            Ignored if `use_fisher` = `False`. Default = 2.6.
         n_mad_floor (optional): Automatically calculate MAD, but can't be lower than
             `n_mad_floor`. If set to `None`, no lower bound. Default = 5.
         n_mad (optional): Use exactly this many MADs to calculate statistical cutoffs.

--- a/scCompare/helpers.py
+++ b/scCompare/helpers.py
@@ -438,8 +438,8 @@ def generate_bulk_sig(
 def derive_statistical_group_cutoff(
     adata_map: anndata.AnnData,
     cluster_key: str,
-    use_fisher: bool = True,
-    alpha: float = 0.05,
+    use_fisher: bool = False,
+    n_stdev: float = 3,
     n_mad_floor: float | None = 5,
     n_mad: float | None = None,
     show_plot: bool = True,
@@ -450,9 +450,9 @@ def derive_statistical_group_cutoff(
         adata_map: Mapping dataset.
         cluster_key: `adata.obs` key to cluster by.
         use_fisher (optional): Whether or not to use a fisher-transformed correlation to
-            derive a p-value for cutting off correlations. Default = `True`.
-        alpha (optional): P-value cutoff if using fisher transformation. Ignored if
-            `use_fisher` = `False`. Default = 0.05.
+            derive a threshold for cutting off correlations. Default = `False`.
+        n_stdev (optional): Standard deviation cutoff if using fisher transformation.
+            Ignored if `use_fisher` = `False`. Default = 3.
         n_mad_floor (optional): Automatically calculate MAD, but can't be lower than
             `n_mad_floor`. If set to `None`, no lower bound. Default = 5.
         n_mad (optional): Use exactly this many MADs to calculate statistical cutoffs.
@@ -467,33 +467,24 @@ def derive_statistical_group_cutoff(
             adata_map, cluster_key, n_mad_floor, n_mad, show_plot
         )
 
-    return _derive_statistical_group_cutoff_fisher(
-        adata_map, cluster_key, alpha
-    )
+    return _derive_statistical_group_cutoff_fisher(adata_map, cluster_key, n_stdev)
 
 
 def _derive_statistical_group_cutoff_fisher(
     adata_map: anndata.AnnData,
     cluster_key: str,
-    alpha: float,
+    n_stdev: float,
 ) -> dict[str, float]:
     print(
-        "Using Z-transformed Pearson Correlation P-value for mapping threshold (alpha: "
-        f"{alpha})"
+        "Using Z-transformed Pearson Correlation stdev for mapping threshold (stdev: "
+        f"{n_stdev})"
     )
     clusters = adata_map.obs[cluster_key].unique()
     stat_group_cutoff = {}
     for cluster in clusters:
         group = adata_map.obs["asgd_pearson"][adata_map.obs[cluster_key] == cluster]
         transform = np.arctanh(group)
-        n = len(transform)
-        ci = stats.t.interval(
-            confidence=1 - (alpha * 2), # Multiply by 2 because the CI should be one-sided
-            df=n - 1,
-            loc=np.mean(transform),
-            scale=np.std(transform, ddof=1)# / np.sqrt(n),
-        )
-        stat_group_cutoff[cluster] = np.tanh(ci[0])
+        stat_group_cutoff[cluster] = transform.mean() - n_stdev * transform.std()
 
     canon_label_asgd = []
     for i in range(len(adata_map.obs)):

--- a/scCompare/scCompare.py
+++ b/scCompare/scCompare.py
@@ -122,8 +122,8 @@ def sc_compare(
     outdir: str = "./scCompare_output",
     n_mad_floor: float = 5,
     n_mad: float = 0,
-    use_fisher: bool = True,
-    alpha: float = 0.05,
+    use_fisher: bool = False,
+    n_stdev: float = 3,
     make_plots: bool = True,
     show_plots: bool = True,
 ) -> AnnData:
@@ -147,9 +147,9 @@ def sc_compare(
         n_mad (optional): Number of MADs to use for cutoff calculation. If set to 0,
             will be statistically calculated by finding the knee. Default = 0.
         use_fisher (optional): Whether or not to use a fisher-transformed correlation to
-            derive a p-value for cutting off correlations. Default = `True`.
-        alpha (optional): P-value cutoff if using fisher transformation. Ignored if
-            `use_fisher` = `False`. Default = 0.05.
+            derive a value for cutting off correlations. Default = `True`.
+        n_stdev (optional): Standard deviation cutoff if using fisher transformation.
+            Ignored if `use_fisher` = `False`. Default = 3.
         make_plots (optional): Make the plots?. Default = `False`.
 
     Returns:
@@ -214,7 +214,7 @@ def sc_compare(
         n_mad_floor=n_mad_floor,
         n_mad=n_mad,
         use_fisher=use_fisher,
-        alpha=alpha,
+        n_stdev=n_stdev,
         show_plot=show_plots,
     )
     print("Done!")

--- a/scCompare/scCompare.py
+++ b/scCompare/scCompare.py
@@ -122,6 +122,8 @@ def sc_compare(
     outdir: str = "./scCompare_output",
     n_mad_floor: float = 5,
     n_mad: float = 0,
+    use_fisher: bool = True,
+    alpha: float = 0.05,
     make_plots: bool = True,
     show_plots: bool = True,
 ) -> AnnData:
@@ -144,6 +146,10 @@ def sc_compare(
             calculated. Default = 5.
         n_mad (optional): Number of MADs to use for cutoff calculation. If set to 0,
             will be statistically calculated by finding the knee. Default = 0.
+        use_fisher (optional): Whether or not to use a fisher-transformed correlation to
+            derive a p-value for cutting off correlations. Default = `True`.
+        alpha (optional): P-value cutoff if using fisher transformation. Ignored if
+            `use_fisher` = `False`. Default = 0.05.
         make_plots (optional): Make the plots?. Default = `False`.
 
     Returns:
@@ -207,6 +213,8 @@ def sc_compare(
         cluster_key=map_cluster_key,
         n_mad_floor=n_mad_floor,
         n_mad=n_mad,
+        use_fisher=use_fisher,
+        alpha=alpha,
         show_plot=show_plots,
     )
     print("Done!")

--- a/scCompare/scCompare.py
+++ b/scCompare/scCompare.py
@@ -123,7 +123,7 @@ def sc_compare(
     n_mad_floor: float = 5,
     n_mad: float = 0,
     use_fisher: bool = False,
-    n_stdev: float = 3,
+    n_stdev: float = 2.6,
     make_plots: bool = True,
     show_plots: bool = True,
 ) -> AnnData:
@@ -149,7 +149,7 @@ def sc_compare(
         use_fisher (optional): Whether or not to use a fisher-transformed correlation to
             derive a value for cutting off correlations. Default = `True`.
         n_stdev (optional): Standard deviation cutoff if using fisher transformation.
-            Ignored if `use_fisher` = `False`. Default = 3.
+            Ignored if `use_fisher` = `False`. Default = 2.6.
         make_plots (optional): Make the plots?. Default = `False`.
 
     Returns:


### PR DESCRIPTION
New `n_stdev` and `use_fisher` parameters allow user to request correlation cut off be determined by N standard deviations of the fisher-transformed correlation distributions rather than using MADs.