### PR TITLE
Handling issues with low cell count groups in the mapping dataset. 

### DIFF
--- a/scCompare/helpers.py
+++ b/scCompare/helpers.py
@@ -415,7 +415,7 @@ def generate_bulk_sig(
     Returns:
         DataFrame of bulk signatures by cluster.
     """
-
+    
     unique_genes = list(
         adata.var["highly_variable"][adata.var["highly_variable"]].index
     )

--- a/scCompare/scCompare.py
+++ b/scCompare/scCompare.py
@@ -84,7 +84,9 @@ def qc_adata_map(
     grouping_key_counts = adata.obs[grouping_key].value_counts()
     insuff_keys = grouping_key_counts.loc[grouping_key_counts < 2].index.tolist()
     if len(insuff_keys) != 0:
-        do_something = 1
+        warning_text = f"keys containing insufficient cells to estimate a distribution will be dropped:{insuff_keys}"
+        warn(warning_text, RuntimeWarning)
+        adata = adata[~adata.obs['canon_label_asgd'].isin(insuff_keys)]
         
     if "highly_variable" not in adata.var:
         error_text = (

--- a/scCompare/scCompare.py
+++ b/scCompare/scCompare.py
@@ -227,7 +227,8 @@ def sc_compare(
     insufficient_postthresh_cells = map_postthresh_grp_counts.loc[map_postthresh_grp_counts < 2].index.tolist()
 
     if len(insufficient_postthresh_cells) != 0:
-        print(f"Categories with less than 2 cells passing thresholding will be excluded from process: {insufficient_postthresh_cells}")
+        warning_text = f"Categories with less than 2 cells passing thresholding will be excluded from process: {insufficient_postthresh_cells}"
+        warn(warning_text, RuntimeWarning)
         adata_map = adata_map[~adata_map.obs['canon_label_asgd'].isin(insufficient_postthresh_cells)]
         bulk_sig.drop(insufficient_postthresh_cells,axis=1,inplace=True)
         for k in insufficient_postthresh_cells:


### PR DESCRIPTION
Two changes:

1. Input objects with below 2 cells in a given group are modified to have this group removed at the very beginning of the pipeline. This is done because multiple cells are required to estimate stat_cutoffs. 
2. For the mapping dataset, groups with low counts in post-threshold annotation are removed from the object  to allow differential expression analysis. 